### PR TITLE
CI IMP2

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -1,0 +1,39 @@
+name: build and unittest
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+
+    container:
+      image: schnitzeltony/fedora-qt5:32
+    steps:
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          repo: ZeraGmbH/zera-metaproject
+          name: buildroot
+          workflow: buildAndExportArtifact.yml
+          path: /github/home/install/
+      - uses: actions/checkout@master
+        with:
+          submodules: recursive
+      - name: Build
+        run: |
+          echo $HOME
+          echo $GITHUB_WORKSPACE
+          cd $HOME
+          mkdir -p "$HOME/targetbuild"
+          cd "$HOME/targetbuild"
+          cmake $GITHUB_WORKSPACE \
+           -DCMAKE_PREFIX_PATH="$HOME/install/usr;/usr" \
+           -DCMAKE_INSTALL_PREFIX:PATH="$HOME/install/usr" \
+           -DCMAKE_INSTALL_SYSCONFDIR="$HOME/install/etc" \
+           -DfirstBuild=ON
+          # compile / install
+           make -j $(getconf _NPROCESSORS_ONLN)

--- a/.github/workflows/triggerMetaUpdates.yml
+++ b/.github/workflows/triggerMetaUpdates.yml
@@ -1,0 +1,27 @@
+name: trigger updates
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  triggerUpdate:
+    runs-on: ubuntu-latest
+    env: 
+      MODULENAME: ${{ github.repository }}
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    
+    steps:
+      - name: cut_modulename
+        run: |
+          echo "MODULENAME=${MODULENAME##*/}" >> $GITHUB_ENV
+      - uses: convictional/trigger-workflow-and-wait@v1.4.0
+        with:
+          owner: ZeraGmbH
+          repo: zera-metaproject
+          github_token: ${{ secrets.G_TRIGGER_WORKFLOW }}
+          workflow_file_name: updateSubmodule.yml
+          inputs: '{"submodule" : "${{ env.MODULENAME }}"}'  
+          ref: master
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+CMakeLists.txt.user*

--- a/dsp.cpp
+++ b/dsp.cpp
@@ -209,7 +209,7 @@ static sDspCmd DspCmd[78] = {	{"INVALID", 0, CMD ,0},
                 {"COPYDATAWDC", 74, CMD3i16, 0 },
                 {"INTEGRALPOS", 75, CMD3i16, 0 },
                 {"INTEGRALNEG", 76, CMD3i16, 0 },
-                {"SUBNVC, 77, CMD3i16, 0"}};
+                {"SUBNVC", 77, CMD3i16, 0}};
 
 
 sDspCmd* findDspCmd(QString& s)

--- a/dsp.cpp
+++ b/dsp.cpp
@@ -132,7 +132,7 @@
 
 #include "dsp.h"
 
-static sDspCmd DspCmd[68] = {	{"INVALID", 0, CMD ,0},
+static sDspCmd DspCmd[69] = {	{"INVALID", 0, CMD ,0},
 				{"USERMEMOFFSET", 1, CMD1i32, 0 },
 				{"DSPMEMOFFSET", 2, CMD1i32, 0 },
 				{"COPYDATA", 3, CMD3i16, 0 },	
@@ -199,7 +199,8 @@ static sDspCmd DspCmd[68] = {	{"INVALID", 0, CMD ,0},
                 {"GETSTIME",64,CMD1i16,0},
                 {"TESTTIMESKIPNEX",65,CMD2i16,0},
                 {"SUBVCC",66,CMD3i16,0},
-                {"SUBVVG",67,CMD3i16,0}};
+                {"SUBVVG",67,CMD3i16,0},
+                {"DSPINTPOST", 68, CMD, 0}};
 
 
 sDspCmd* findDspCmd(QString& s)

--- a/dsp.cpp
+++ b/dsp.cpp
@@ -132,7 +132,7 @@
 
 #include "dsp.h"
 
-static sDspCmd DspCmd[69] = {	{"INVALID", 0, CMD ,0},
+static sDspCmd DspCmd[78] = {	{"INVALID", 0, CMD ,0},
 				{"USERMEMOFFSET", 1, CMD1i32, 0 },
 				{"DSPMEMOFFSET", 2, CMD1i32, 0 },
 				{"COPYDATA", 3, CMD3i16, 0 },	
@@ -200,7 +200,16 @@ static sDspCmd DspCmd[69] = {	{"INVALID", 0, CMD ,0},
                 {"TESTTIMESKIPNEX",65,CMD2i16,0},
                 {"SUBVCC",66,CMD3i16,0},
                 {"SUBVVG",67,CMD3i16,0},
-                {"DSPINTPOST", 68, CMD, 0}};
+                {"DSPINTPOST", 68, CMD, 0},
+                {"SETPEAK", 69, CMD2i16, 0},
+                {"COPYDATAIND", 70, CMD3i16, 0},
+                {"INTERPOLATIONIND", 71, CMD3i16, 0},
+                {"COPYMEM", 72, CMD3i16, 0 },
+                {"GENADR",73,CMD3i16,0 },
+                {"COPYDATAWDC", 74, CMD3i16, 0 },
+                {"INTEGRALPOS", 75, CMD3i16, 0 },
+                {"INTEGRALNEG", 76, CMD3i16, 0 },
+                {"SUBNVC, 77, CMD3i16, 0"}};
 
 
 sDspCmd* findDspCmd(QString& s)

--- a/dsp.cpp
+++ b/dsp.cpp
@@ -238,7 +238,7 @@ sMemSection dm32DspWorkspace = {
 
 sDspVar DialogWorkSpaceVar[18] = 	{ 	  {"DSPCMDPAR",10,eInt,0},		// 10 werte cmds, paramter ... ctrl -> dsp
 					  {"DSPACK",1,eInt,0},			// semaphore ackn. dsp -> cntr.
-					  {"CTRLCMDPAR",10,eInt,0},		// 10 werte cmds, paramter ... dsp -> ctrl
+                      {"CTRLCMDPAR",20,eInt,0},		// 10 werte cmds, paramter ... dsp -> ctrl
 					  {"CTRLACK",1,eInt,0},			// semaphore ackn. ctrl. -> dsp
 					  {"FREQUENCYNORM",4,eFloat,0},		// 4 freq. normierungswerte
 					  {"GAINCORRECTION",32,eFloat,0},		// 32 verstärkungskorrekturwerte
@@ -253,7 +253,7 @@ sDspVar DialogWorkSpaceVar[18] = 	{ 	  {"DSPCMDPAR",10,eInt,0},		// 10 werte cmd
 					  {"ETHDESTSOURCEADRESS",3,eInt,0},	// 3*32bit -> 2*48bit
 					  {"ETHPRIORITYTAGGED",1,eInt,0},
 					  {"ETHTYPEAPPID",1,eInt,0},
-					  {"ETHROUTINGTAB",8,eInt,0} };		// 8*4 = 32 byte 1byte/kanal ASDU / CHN
+                      {"ETHROUTINGTAB",16,eInt,0} };		// 8*4 = 32 byte 1byte/kanal ASDU / CHN
 
 
 

--- a/zdsp1d.cpp
+++ b/zdsp1d.cpp
@@ -1704,8 +1704,13 @@ bool cZDSP1Server::LoadDSProgram()
             for ( int i = 0; i < cmdl2.size(); i++ ) mds2 << cmdl2[i]; // interrupt liste
         }
     }
-    s =  QString( "INVALID()");
+
     client = it.toFirst();
+    s = QString( "DSPINTPOST()"); // wir triggern das senden der serialisierten interrupts
+    cmd = client->GenDspCmd(s, &ok);
+    mds1 << cmd;
+
+    s =  QString( "INVALID()");
     cmd = client->GenDspCmd(s, &ok);
     mds1 << cmd; // kommando listen ende
     mds2 << cmd;

--- a/zdsp1d.cpp
+++ b/zdsp1d.cpp
@@ -756,11 +756,6 @@ cZDSP1Server::~cZDSP1Server()
     close(DevFileDescriptor); // close dev.
 }
 
-/*
-void cZDSP1Server::DspIntService(int)
-{
-}
-*/
 
 int cZDSP1Server::DspDevOpen()
 {

--- a/zdsp1d.h
+++ b/zdsp1d.h
@@ -111,7 +111,6 @@ public:
     int DspDevSeek(int,ulong);
     int DspDevOpen();
     
-    void DspIntService(int);
     int DevFileDescriptor; // kerneltreiber wird nur 1x geöffnet und dann gehalten
     int DebugLevel;
     

--- a/zdspglobal.h
+++ b/zdspglobal.h
@@ -33,12 +33,15 @@
 // neue befehle für dsp
 // {"SUBVCC",66,CMD3i16,0}}
 //  eingeführt. ..... läuft aber erst mit dsp ab version 3.08
-
+//v1.09
+// im en61850 decoder war eine änderung notwendig...diese wurde im dsp ab v3.16 realisiert
+// mittlerweile hatte sich das memory mapping in dialogworkspace geändert und musste daher
+// angepasst werden.
 
 
 #define DSPDeviceNode "/dev/zFPGA1dsp1"
 #define ServerBasisName "zdsp1d"
-#define ServerVersion "V1.08"
+#define ServerVersion "V1.09"
 #define InpBufSize 4096
 
 // wenn DEBUG -> kein fork() 

--- a/zdspglobal.h
+++ b/zdspglobal.h
@@ -40,11 +40,15 @@
 // kommandoliste angehängt werden muss, weil wir aus gründen von interrupt latenzen im
 // dsp auf queued interrupts umgestellt hatten. darüber hinaus musste der interrupt handler
 // geändert werden.
-
+//v1.10
+// es wurden mehrere Kommandos für den dsp ergänzt. die liste war für den com5003 bereits gewachsen
+// und für die wm3000 musste ein kommando ergänzt werden damit der dc aus den messperioden herausgerechnet
+// werden kann. dies ist erforderlich für die amplitudenjustage weil zera referenzgeräte immer noch ohne
+// dc arbeiten.
 
 #define DSPDeviceNode "/dev/zFPGA1dsp1"
 #define ServerBasisName "zdsp1d"
-#define ServerVersion "V1.09"
+#define ServerVersion "V1.10"
 #define InpBufSize 4096
 
 // wenn DEBUG -> kein fork() 

--- a/zdspglobal.h
+++ b/zdspglobal.h
@@ -36,7 +36,10 @@
 //v1.09
 // im en61850 decoder war eine änderung notwendig...diese wurde im dsp ab v3.16 realisiert
 // mittlerweile hatte sich das memory mapping in dialogworkspace geändert und musste daher
-// angepasst werden.
+// angepasst werden. es wurde ein dsp cmd DSPINTPOST eingeführt welches ans ende aller
+// kommandoliste angehängt werden muss, weil wir aus gründen von interrupt latenzen im
+// dsp auf queued interrupts umgestellt hatten. darüber hinaus musste der interrupt handler
+// geändert werden.
 
 
 #define DSPDeviceNode "/dev/zFPGA1dsp1"


### PR DESCRIPTION
- dsp.cpp, zdspglobal.h : changed dsp memory map and version number
- dsp.cpp: added command DSPINTPOST for new interrupthandling
- zdsp1d.cpp: added command DSPINTPOST to end of cmdlist
- zdsp1d.cpp,h: changed DSPIntHandler for handling queued interrupts
- zdsp1d.cpp: removed old dspintservice
- zdspglobal.h: added comments for version description
- dsp.cpp: added several commands to support new dsp macros
- zdspglobal.h: version number changed
- dsp.cpp: bugfix SUBNVC command
- Ignore qt-creator generated temp files
- Add basic CI
